### PR TITLE
feat: add client case studies, unify status badges to Live/Building

### DIFF
--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -16,7 +16,7 @@ const featuredProducts = [
         description:
             "Converts job postings into complete application packs via Telegram — OCR ingestion, LLM resume mutation with truthfulness guards, LaTeX compilation, and eval-gated CI preventing regressions.",
         stack: "Python · FastAPI · OpenRouter · LaTeX · PostgreSQL · Telegram · Railway",
-        status: "Production",
+        status: "Live",
         caseStudySlug: "job-search-agent",
         tags: ["AI", "Agents", "Eval"],
     },
@@ -26,7 +26,7 @@ const featuredProducts = [
         description:
             "Admin panel with RBAC (5 roles), recurring event management, Hootsuite social posting, gallery uploads, payment session tracking, and audit logging.",
         stack: "React · TypeScript · Vite · Supabase · Tailwind · Shadcn/ui",
-        status: "Completed",
+        status: "Live",
         tags: ["Product Build", "Infra", "Systems"],
     },
     {
@@ -35,8 +35,28 @@ const featuredProducts = [
         description:
             "Landing page routing users to food ordering and community/events ecosystem. Shipped fast with Next.js 16 App Router and Framer Motion animations.",
         stack: "Next.js 16 · Framer Motion · Tailwind",
-        status: "Shipped",
+        status: "Live",
         tags: ["Design", "Product Build"],
+    },
+    {
+        title: "Mental Health Platform Rebuild",
+        tagline: "Client: full website rebuild with SEO & lead capture",
+        description:
+            "Complete website rebuild for a mental health startup — SEO-first architecture, lead capture quiz, structured content, and deployment pipeline.",
+        stack: "Next.js · JavaScript · SEO",
+        status: "Live",
+        caseStudySlug: "mental-health-platform",
+        tags: ["Client Work", "Full-Stack", "SEO"],
+    },
+    {
+        title: "Quant Trading Platform",
+        tagline: "Client: broker integrations & order execution",
+        description:
+            "Python trading platform with broker OAuth/TOTP authentication, order execution pipeline, and automated smoke testing. Docker containerized.",
+        stack: "Python · Docker · OAuth · REST APIs",
+        status: "Building",
+        caseStudySlug: "quant-trading-platform",
+        tags: ["Client Work", "Python", "Fintech"],
     },
 ];
 
@@ -47,7 +67,7 @@ const products = [
         description:
             "AI-led design commerce MVP. Users describe a t-shirt design in words, the system generates and previews it on a real-time canvas. Exploring prompt-to-purchase flows.",
         stack: "React · fabric.js · Supabase · OpenAI (GPT-4o / DALL-E)",
-        status: "MVP",
+        status: "Building",
         caseStudySlug: "merekapade",
         liveUrl: "https://merekapade.com",
         liveLabel: "Live",

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -56,7 +56,7 @@ const featuredWork = [
     {
         name: "Job Search Agent",
         description: "Multi-agent AI, eval gates, Telegram, LaTeX",
-        status: "Production",
+        status: "Live",
         caseStudyHref: "/work/job-search-agent",
     },
     {
@@ -69,7 +69,7 @@ const featuredWork = [
     {
         name: "MereKapade",
         description: "AI design commerce, fabric.js canvas, GPT",
-        status: "MVP",
+        status: "Building",
         caseStudyHref: "/work/merekapade",
         liveUrl: "https://merekapade.com",
     },

--- a/src/data/case-studies.ts
+++ b/src/data/case-studies.ts
@@ -464,6 +464,93 @@ export const caseStudies: CaseStudy[] = [
         ],
     },
     {
+        slug: "mental-health-platform",
+        title: "Website Rebuild for a Mental Health Platform",
+        summary:
+            "Full website rebuild for a mental health startup — SEO implementation, lead capture quiz, structured content architecture, and deployment pipeline.",
+        kpis: [
+            "Complete rebuild shipped",
+            "SEO-first architecture",
+            "Lead capture quiz",
+            "3 priority bands delivered",
+        ],
+        tags: ["Client Work", "Full-Stack", "SEO", "Product Build"],
+        tech: ["Next.js", "JavaScript", "SEO", "Sitemap/Robots.txt"],
+        sections: [
+            {
+                heading: "Overview",
+                content:
+                    "A mental health platform needed their website rebuilt from scratch — better SEO, a lead capture mechanism, and a structured content architecture that could scale.",
+            },
+            {
+                heading: "Context & Role",
+                content:
+                    "Freelance engagement. Owned the full rebuild — scope definition, technical architecture, implementation, and deployment.",
+            },
+            {
+                heading: "What Shipped",
+                content:
+                    "Complete website rebuild with SEO-first architecture — sitemap, robots.txt, meta tags, structured data. Mental Fitness Quiz as the primary lead capture mechanism. Content architecture designed for scalability. Delivered in 3 priority bands with clear scope boundaries.",
+            },
+            {
+                heading: "Product Decisions",
+                content:
+                    "Prioritised SEO fundamentals before visual polish — the site needed to be discoverable before it needed to be pretty. Designed the quiz as a progressive engagement tool rather than a gated form.",
+            },
+            {
+                heading: "Lessons",
+                content:
+                    "Scope-of-work documents with priority bands prevent scope creep and set clear expectations. SEO implementation from day one compounds over time.",
+            },
+        ],
+    },
+    {
+        slug: "quant-trading-platform",
+        title: "Quant Trading Platform with Broker Integrations",
+        summary:
+            "Python-based trading platform with broker OAuth/TOTP authentication, order execution pipeline, and automated smoke testing — containerized with Docker.",
+        kpis: [
+            "Broker OAuth + TOTP auth",
+            "Order execution pipeline",
+            "Smoke test suite",
+            "Docker containerized",
+        ],
+        tags: ["Client Work", "Python", "Fintech", "Infrastructure"],
+        tech: ["Python", "Docker", "Shell", "OAuth", "REST APIs"],
+        sections: [
+            {
+                heading: "Overview",
+                content:
+                    "A fintech client needed a quant trading platform that could authenticate with Indian brokers, execute orders programmatically, and run automated smoke tests to verify connectivity and order flow.",
+            },
+            {
+                heading: "Context & Role",
+                content:
+                    "Freelance engagement. Owned architecture, broker integration, authentication flows, and deployment infrastructure.",
+            },
+            {
+                heading: "What Shipped",
+                content:
+                    "Broker authentication via OAuth and TOTP (supporting direct-connect flows). Order placement pipeline with session management. Automated smoke testing suite for connectivity and order validation. Docker containerized for reproducible deployment.",
+            },
+            {
+                heading: "Product Decisions",
+                content:
+                    "Built authentication as a modular layer — new brokers can be added without touching the order pipeline. Smoke tests run on every deployment to catch broker API changes early. Containerized from day one to avoid environment drift.",
+            },
+            {
+                heading: "Challenges",
+                content:
+                    "Indian broker APIs have inconsistent auth flows — some use OAuth, others TOTP, some both. Built an abstraction layer that normalizes these into a single session interface.",
+            },
+            {
+                heading: "Lessons",
+                content:
+                    "Financial APIs need defensive engineering — session timeouts, retry logic, and smoke tests aren't optional. Modular auth layers pay off when integrating multiple providers.",
+            },
+        ],
+    },
+    {
         slug: "content-ops-automation",
         title: "Content Ops → Predictable, Measurable, Sprint-Driven",
         summary:


### PR DESCRIPTION
- Add anonymized case studies: Mental Health Platform Rebuild, Quant Trading Platform
- Add both as product cards on /products page
- Unify all status badges: Live (shipped) or Building (in progress)
- Sitemap auto-includes new case study routes (9 total)